### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/network/packets/play/S2CSpawnEntityPacket.ts
+++ b/network/packets/play/S2CSpawnEntityPacket.ts
@@ -44,7 +44,7 @@ export default class S2CSpawnEntityPacket extends S2CPacket {
                 throw new Error('Paintings should only be spawned with the S2CSpawnPainting packet!')
             case EntityType.MARKER:
                 throw new Error(
-                    'Marker entities should never be spawned! (See https://minecraft.fandom.com/wiki/Marker)'
+                    'Marker entities should never be spawned! (See https://minecraft.wiki/w/Marker)'
                 )
         }
 

--- a/network/packets/play/S2CSpawnLivingEntityPacket.ts
+++ b/network/packets/play/S2CSpawnLivingEntityPacket.ts
@@ -29,7 +29,7 @@ export default class S2CSpawnLivingEntityPacket extends S2CPacket {
                 throw new Error('Paintings should only be spawned with the S2CSpawnPainting packet!')
             case EntityType.MARKER:
                 throw new Error(
-                    'Marker entities should never be spawned! (See https://minecraft.fandom.com/wiki/Marker)'
+                    'Marker entities should never be spawned! (See https://minecraft.wiki/w/Marker)'
                 )
             case EntityType.AREA_EFFECT_CLOUD:
             case EntityType.ARROW:


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki